### PR TITLE
Adding a method to return the details of the icap request

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -15,7 +15,8 @@ module.exports = function createIcapRequest(icapDetails, connection) {
         getRawRequestHeaders,
         getRawResponseHeaders,
         getPreview,
-        getRawBody
+        getRawBody,
+        getIcapDetails
     });
 
     function hasRequestHeaders() {
@@ -77,6 +78,10 @@ module.exports = function createIcapRequest(icapDetails, connection) {
                 const [headers, body] = results;
                 return createHttpRequest(headers, body);
             });
+    }
+
+    function getIcapDetails() {
+        return icapDetails;     
     }
 };
 


### PR DESCRIPTION
This patch was created in order to get the details of the ICAP request like custom headers, icap version, etc.